### PR TITLE
Add OS X with Homebrew support

### DIFF
--- a/so-create-repo.sh
+++ b/so-create-repo.sh
@@ -34,6 +34,10 @@ check_and_install_requirements()
         if [ -z $INSTALLER ]; then
                 INSTALLER=$(which yum)
         fi
+        
+        if [ -z $INSTALLER ]; then
+                INSTALLER=$(which brew)
+        fi
 
         if [ -z $INSTALLER ]; then
                 echo -e "error: Distribution not supported. Please contribute to

--- a/so-create-repo.sh
+++ b/so-create-repo.sh
@@ -31,12 +31,14 @@ check_and_install_requirements()
         # exit if it fails
 
         INSTALLER=$(which apt-get)
+        SUDO=sudo
         if [ -z $INSTALLER ]; then
                 INSTALLER=$(which yum)
         fi
         
         if [ -z $INSTALLER ]; then
                 INSTALLER=$(which brew)
+                SUDO=""
         fi
 
         if [ -z $INSTALLER ]; then
@@ -52,7 +54,7 @@ check_and_install_requirements()
                 which $package > /dev/null
                 if [ $? -ne 0 ]; then
                         echo -e "info: $package not available on the system. Installing...\n"
-                        sudo $INSTALLER install $package -y
+                        $SUDO $INSTALLER install $package -y
                         if [ $? -ne 0 ]; then
                                 echo -e "error: Failed installing $package. Aborting ...\n"
                                 exit 1


### PR DESCRIPTION
OS X comes with `git`, `ssh` and `curl` preinstalled (providing you install XCode or the CLI tools, which are a requirement for `brew` anyway). Most people use `brew` as a package manager and `jq` can be installed from there.

Otherwise, the script works fine.
