### PR TITLE
Fail test for NR_RUNS allocs

### DIFF
--- a/1-multi/checker/multi/_test/run_test.sh
+++ b/1-multi/checker/multi/_test/run_test.sh
@@ -160,6 +160,8 @@ run_until_success()
 		fi
 
 	done
+	basic_test false
+	return -1
 }
 
 test_so_alloc()


### PR DESCRIPTION
The run_test.sh script in the first homework's checker could falsely give a positive answer for test 38 if more than NR_RUNS allocs were attempted. The test should now fail if that happens.