### PR TITLE
fix skip_memcheck

### DIFF
--- a/4-scheduler/checker-lin/run_all.sh
+++ b/4-scheduler/checker-lin/run_all.sh
@@ -149,7 +149,7 @@ test_sched()
         fi
     done
 
-    if [ $skip_memcheck ]; then
+    if [ "$skip_memcheck" = "true" ]; then
         timeout $timeout ./_test/"$script" $test_index &> /dev/null
     else
         timeout $timeout $MEMCHECK ./_test/"$script" $test_index &> /dev/null

--- a/4-scheduler/checker-win/run_all.sh
+++ b/4-scheduler/checker-win/run_all.sh
@@ -147,7 +147,7 @@ test_sched()
         fi
     done
 
-    if [ $skip_memcheck ]; then
+    if [ "$skip_memcheck" = "true" ]; then
         timeout $timeout ./_test/"$script" $test_index &> /dev/null
     else
         timeout $timeout $MEMCHECK ./_test/"$script" $test_index &> /dev/null


### PR DESCRIPTION
compare the value of skip_memcheck instead of testing if it is not empty.
skip_memcheck must be quoted, otherwise bash will treat it like a command
and run it (will execute the builtin "true" or "false).

VAL=value ; if [ $VAL ] ; then echo "foo" ; else echo "bar" ; fi

will print foo regardless if value is true or false, because this
is equivalent to [ -n $VAL ] (verifies that length of output of command
$VAL is nonzero).